### PR TITLE
Improvements to cloud-init and keypair support

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ output "controlplane_data" {
 | <a name="input_copilot_service_account_password"></a> [copilot\_service\_account\_password](#input\_copilot\_service\_account\_password) | n/a | `string` | `""` | no |
 | <a name="input_customer_id"></a> [customer\_id](#input\_customer\_id) | aviatrix customer license id | `string` | n/a | yes |
 | <a name="input_incoming_ssl_cidrs"></a> [incoming\_ssl\_cidrs](#input\_incoming\_ssl\_cidrs) | Incoming cidrs for security group used by controller | `list(string)` | n/a | yes |
-| <a name="input_module_config"></a> [module\_config](#input\_module\_config) | n/a | `map` | <pre>{<br/>  "account_onboarding": true,<br/>  "controller_deployment": true,<br/>  "controller_initialization": true,<br/>  "copilot_deployment": true,<br/>  "copilot_initialization": true,<br/>  "iam_roles": true<br/>}</pre> | no |
+| <a name="input_module_config"></a> [module\_config](#input\_module\_config) | n/a | `map` | <pre>{<br>  "account_onboarding": true,<br>  "controller_deployment": true,<br>  "controller_initialization": true,<br>  "copilot_deployment": true,<br>  "copilot_initialization": true,<br>  "iam_roles": true<br>}</pre> | no |
 | <a name="input_subnet_id"></a> [subnet\_id](#input\_subnet\_id) | Subnet ID, only required when use\_existing\_vpc is true. | `string` | `""` | no |
 | <a name="input_subnet_name"></a> [subnet\_name](#input\_subnet\_name) | subnet name, only required when use\_existing\_vpc is true. | `string` | `""` | no |
 | <a name="input_use_existing_vpc"></a> [use\_existing\_vpc](#input\_use\_existing\_vpc) | Flag to indicate whether to use an existing VPC | `bool` | `false` | no |

--- a/main.tf
+++ b/main.tf
@@ -16,12 +16,14 @@ module "controller_build" {
   vpc_id             = var.vpc_id
   subnet_id          = var.subnet_id
 
-  availability_zone = var.availability_zone
-  vpc_cidr          = var.controlplane_vpc_cidr
-  subnet_cidr       = var.controlplane_subnet_cidr
-  environment       = var.environment              #For internal use only
-  ami_id            = var.controller_ami_id        #For internal use only
-  key_pair_name     = var.controller_key_pair_name #For internal use only
+  availability_zone    = var.availability_zone
+  vpc_cidr             = var.controlplane_vpc_cidr
+  subnet_cidr          = var.controlplane_subnet_cidr
+  environment          = var.environment                     #For internal use only
+  ami_id               = var.controller_ami_id               #For internal use only
+  use_existing_keypair = var.controller_use_existing_keypair #For internal use only
+  key_pair_name        = var.controller_key_pair_name        #For internal use only
+  registry_auth_token  = var.registry_auth_token             #For internal use only
 
   depends_on = [
     module.iam_roles

--- a/modules/controller_build/cloud-init-prod.yml
+++ b/modules/controller_build/cloud-init-prod.yml
@@ -1,3 +1,0 @@
-#cloud-config
-avx-controller:
-  avx-controller-version: latest

--- a/modules/controller_build/cloud-init-staging.yml
+++ b/modules/controller_build/cloud-init-staging.yml
@@ -1,4 +1,0 @@
-#cloud-config
-avx-controller:
-  environment: staging
-  avx-controller-version: latest

--- a/modules/controller_build/cloud-init.tftpl
+++ b/modules/controller_build/cloud-init.tftpl
@@ -1,0 +1,7 @@
+#cloud-config
+avx-controller:
+  avx-controller-version: latest
+  environment: ${environment}
+  extra-bootstrap-args:
+    image-registry: registry-release.${environment}.sre.aviatrix.com
+    image-registry-auth: ${registry_auth_token}

--- a/modules/controller_build/variables.tf
+++ b/modules/controller_build/variables.tf
@@ -177,6 +177,13 @@ variable "environment" {
   }
 }
 
+# terraform-docs-ignore
+variable "registry_auth_token" {
+  description = "The token used to authenticate to the controller artifact registry. For internal use only."
+  type        = string
+  default     = ""
+  nullable    = false
+}
 
 locals {
   name_prefix       = var.name_prefix != "" ? "${var.name_prefix}_" : ""
@@ -194,6 +201,11 @@ locals {
       module    = "aviatrix-controller-build"
       Createdby = "Terraform+Aviatrix"
   })
+
+  cloud_init = base64encode(templatefile("${path.module}/cloud-init.tftpl", {
+    environment         = var.environment
+    registry_auth_token = var.registry_auth_token
+  }))
 }
 
 data "http" "avx_ami_id" {

--- a/variables.tf
+++ b/variables.tf
@@ -49,6 +49,13 @@ variable "controller_ami_id" {
 }
 
 # terraform-docs-ignore
+variable "controller_use_existing_keypair" {
+  type        = bool
+  default     = false
+  description = "Flag to indicate whether to use an existing key pair"
+}
+
+# terraform-docs-ignore
 variable "controller_key_pair_name" {
   type        = string
   description = "Key pair name"
@@ -144,4 +151,12 @@ variable "environment" {
     condition     = contains(["prod", "staging"], var.environment)
     error_message = "The environment must be either 'prod' or 'staging'."
   }
+}
+
+# terraform-docs-ignore
+variable "registry_auth_token" {
+  description = "The token used to authenticate to the controller artifact registry. For internal use only."
+  type        = string
+  default     = ""
+  nullable    = false
 }


### PR DESCRIPTION
Use a single template for environments with parametrization. Add support
for a few internal-only variables.
