### PR TITLE
Allow user defined tags and name_prefix

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -26,7 +26,7 @@ module "controller_build" {
   key_pair_name             = var.controller_key_pair_name        #For internal use only
   registry_auth_token       = var.registry_auth_token             #For internal use only
   additional_bootstrap_args = var.additional_bootstrap_args       #For internal use only
-
+  tags                      = var.tags
   depends_on = [
     module.iam_roles
   ]
@@ -69,7 +69,7 @@ module "copilot_build" {
   environment              = var.environment                  #For internal use only
   use_existing_keypair     = var.copilot_use_existing_keypair #For internal use only
   key_pair_name            = var.copilot_key_pair_name        #For internal use only
-
+  tags                     = var.tags
   allowed_cidrs = {
     "tcp_cidrs" = {
       protocol = "Tcp"

--- a/main.tf
+++ b/main.tf
@@ -27,6 +27,7 @@ module "controller_build" {
   registry_auth_token       = var.registry_auth_token             #For internal use only
   additional_bootstrap_args = var.additional_bootstrap_args       #For internal use only
   tags                      = var.tags
+  name_prefix               = var.name_prefix
   depends_on = [
     module.iam_roles
   ]
@@ -70,6 +71,7 @@ module "copilot_build" {
   use_existing_keypair     = var.copilot_use_existing_keypair #For internal use only
   key_pair_name            = var.copilot_key_pair_name        #For internal use only
   tags                     = var.tags
+  name_prefix              = var.name_prefix
   allowed_cidrs = {
     "tcp_cidrs" = {
       protocol = "Tcp"

--- a/variables.tf
+++ b/variables.tf
@@ -188,3 +188,9 @@ variable "tags" {
   type        = map(string)
   default     = {}
 }
+
+variable "name_prefix" {
+  description = "Prefix to apply to all resources"
+  type        = string
+  default     = ""
+}

--- a/variables.tf
+++ b/variables.tf
@@ -182,3 +182,9 @@ variable "additional_bootstrap_args" {
   type        = map(any)
   default     = {}
 }
+
+variable "tags" {
+  description = "Tags to apply to all resources"
+  type        = map(string)
+  default     = {}
+}


### PR DESCRIPTION
Allow user defined tags and name_prefix to differentiate containerized controller deployed simultaneously in different workflows (e.g Github Actions Run id as unique identifier)