### PR TITLE
Show copilot security group id for testing purposes

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,4 +67,5 @@ output "controlplane_data" {
 | <a name="output_controller_vpc_id"></a> [controller\_vpc\_id](#output\_controller\_vpc\_id) | n/a |
 | <a name="output_copilot_private_ip"></a> [copilot\_private\_ip](#output\_copilot\_private\_ip) | n/a |
 | <a name="output_copilot_public_ip"></a> [copilot\_public\_ip](#output\_copilot\_public\_ip) | n/a |
+| <a name="output_copilot_security_group_id"></a> [copilot\_security\_group\_id](#output\_copilot\_security\_group\_id) | n/a |
 <!-- END_TF_DOCS -->

--- a/modules/copilot_build/outputs.tf
+++ b/modules/copilot_build/outputs.tf
@@ -27,3 +27,8 @@ output "region" {
   value       = data.aws_region.current.name
   description = "Current AWS region"
 }
+
+output "security_group_id" {
+  value       = aws_security_group.copilot_security_group.id
+  description = "Security group ID"
+}

--- a/output.tf
+++ b/output.tf
@@ -14,6 +14,10 @@ output "copilot_private_ip" {
   value = var.module_config.copilot_deployment ? module.copilot_build[0].private_ip : null
 }
 
+output "copilot_security_group_id" {
+  value = var.module_config.copilot_deployment ? module.copilot_build[0].security_group_id : null
+}
+
 output "controller_instance_id" {
   value = var.module_config.controller_deployment ? module.controller_build[0].instance_id : null
 }


### PR DESCRIPTION
The copilot module has this info in output.tf but this module does not have an output for this value which is necessary for automation with containerized copilot instance.