### PR TITLE
Fix for deploying to clean accounts with no avx iam

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -1,5 +1,31 @@
+data "aws_availability_zones" "all" {
+  filter {
+    name   = "opt-in-status"
+    values = ["opt-in-not-required"]
+  }
+}
+
+data "aws_ec2_instance_type_offering" "offering" {
+  for_each = toset(data.aws_availability_zones.all.names)
+
+  filter {
+    name   = "instance-type"
+    values = ["t2.micro", "t3.micro", var.controller_instance_type]
+  }
+
+  filter {
+    name   = "location"
+    values = [each.value]
+  }
+
+  location_type = "availability-zone"
+
+  preferred_instance_types = [var.controller_instance_type, "t3.micro", "t2.micro"]
+}
+
 locals {
   copilot_service_account_password = coalesce(var.copilot_service_account_password, var.controller_admin_password)
   copilot_public_ip                = var.module_config.copilot_deployment ? [format("%s/32", module.copilot_build[0].public_ip)] : []
   controller_allowed_cidrs         = concat(var.incoming_ssl_cidrs, local.copilot_public_ip)
+  default_az                       = keys({ for az, details in data.aws_ec2_instance_type_offering.offering : az => details.instance_type if details.instance_type == var.controller_instance_type })[0]
 }

--- a/main.tf
+++ b/main.tf
@@ -65,6 +65,7 @@ module "copilot_build" {
   controller_public_ip     = module.controller_build[0].public_ip
   controller_private_ip    = module.controller_build[0].private_ip
   copilot_name             = var.copilot_name
+  ami_id                   = var.copilot_ami_id
   instance_type            = var.copilot_instance_type
   default_data_volume_name = "/dev/sdf"
   default_data_volume_size = "100"

--- a/main.tf
+++ b/main.tf
@@ -17,7 +17,7 @@ module "controller_build" {
   vpc_id             = var.vpc_id
   subnet_id          = var.subnet_id
 
-  availability_zone         = var.availability_zone
+  availability_zone         = var.availability_zone == "" ? local.default_az : var.availability_zone
   vpc_cidr                  = var.controlplane_vpc_cidr
   subnet_cidr               = var.controlplane_subnet_cidr
   environment               = var.environment                     #For internal use only
@@ -65,6 +65,7 @@ module "copilot_build" {
   controller_public_ip     = module.controller_build[0].public_ip
   controller_private_ip    = module.controller_build[0].private_ip
   copilot_name             = var.copilot_name
+  instance_type            = var.copilot_instance_type
   default_data_volume_name = "/dev/sdf"
   default_data_volume_size = "100"
   environment              = var.environment                  #For internal use only

--- a/modules/account_onboarding/main.tf
+++ b/modules/account_onboarding/main.tf
@@ -12,8 +12,8 @@ data "http" "controller_login" {
     password = var.controller_admin_password,
   })
   retry {
-    attempts     = 30
-    min_delay_ms = 10000
+    attempts     = 5
+    min_delay_ms = 1000
   }
   lifecycle {
     postcondition {

--- a/modules/account_onboarding/main.tf
+++ b/modules/account_onboarding/main.tf
@@ -12,8 +12,8 @@ data "http" "controller_login" {
     password = var.controller_admin_password,
   })
   retry {
-    attempts     = 5
-    min_delay_ms = 1000
+    attempts     = 30
+    min_delay_ms = 10000
   }
   lifecycle {
     postcondition {

--- a/modules/controller_build/main.tf
+++ b/modules/controller_build/main.tf
@@ -40,7 +40,7 @@ resource "aws_subnet" "controller_subnet" {
   count             = var.use_existing_vpc ? 0 : 1
   vpc_id            = aws_vpc.controller_vpc[0].id
   cidr_block        = var.subnet_cidr
-  availability_zone = local.availability_zone
+  availability_zone = var.availability_zone
   tags = {
     Name = "${local.name_prefix}controller_subnet"
   }

--- a/modules/copilot_build/variables.tf
+++ b/modules/copilot_build/variables.tf
@@ -89,6 +89,13 @@ variable "instance_type" {
   default     = ""
 }
 
+variable "ami_id" {
+  type        = string
+  description = "AMI ID for copilot. If unset, use official image."
+  default     = ""
+  nullable    = false
+}
+
 variable "name_prefix" {
   type        = string
   description = "Additional name prefix for your environment resources"
@@ -197,7 +204,7 @@ locals {
   name_prefix         = var.name_prefix != "" ? "${var.name_prefix}_" : ""
   images_copilot      = jsondecode(data.http.copilot_iam_id.response_body).Copilot
   images_copilotarm   = jsondecode(data.http.copilot_iam_id.response_body).CopilotARM
-  ami_id              = var.type == "Copilot" ? local.images_copilot[data.aws_region.current.name] : local.images_copilotarm[data.aws_region.current.name]
+  ami_id              = var.ami_id != "" ? var.ami_id : var.type == "Copilot" ? local.images_copilot[data.aws_region.current.name] : local.images_copilotarm[data.aws_region.current.name]
   instance_type       = var.instance_type != "" ? var.instance_type : (var.type == "Copilot" ? "m5.2xlarge" : "t4g.2xlarge")
   default_az          = keys({ for az, details in data.aws_ec2_instance_type_offering.offering : az => details.instance_type if details.instance_type == local.instance_type })[0]
   availability_zone   = var.availability_zone != "" ? var.availability_zone : local.default_az

--- a/variables.tf
+++ b/variables.tf
@@ -49,6 +49,14 @@ variable "controller_ami_id" {
 }
 
 # terraform-docs-ignore
+variable "copilot_ami_id" {
+  type        = string
+  description = "AMI ID for copilot. If unset, use official image."
+  default     = ""
+  nullable    = false
+}
+
+# terraform-docs-ignore
 variable "controller_use_existing_keypair" {
   type        = bool
   default     = false

--- a/variables.tf
+++ b/variables.tf
@@ -144,6 +144,12 @@ variable "controller_instance_type" {
   default     = "t3.large"
 }
 
+variable "copilot_instance_type" {
+  type        = string
+  description = "The instance type used for deploying copilot."
+  default     = null
+}
+
 variable "module_config" {
   default = {
     controller_deployment     = true,


### PR DESCRIPTION
Completing the change originally proposed by @avx-rchung in https://github.com/terraform-aviatrix-modules/terraform-aviatrix-aws-controlplane/pull/3.

- Moves the az calculation out of the `controller_build` module and into root.
- Takes @Dennizz 's suggestion in https://github.com/terraform-aviatrix-modules/terraform-aviatrix-aws-controlplane/pull/3 to move logic from module call to locals.
- Makes CoPilot `instance_type` configurable.
- Makes CoPilot `ami_id` configurable.