### PR TITLE
Update AWS region reference

### DIFF
--- a/modules/controller_build/variables.tf
+++ b/modules/controller_build/variables.tf
@@ -182,9 +182,9 @@ locals {
   controller_name = var.controller_name != "" ? var.controller_name : "${local.name_prefix}AviatrixController"
   key_pair_name   = var.key_pair_name != "" ? var.key_pair_name : "aviatrix_controller_kp"
   ec2_role_name   = var.ec2_role_name != "" ? var.ec2_role_name : "aviatrix-role-ec2"
-  is_aws_cn       = element(split("-", data.aws_region.current.name), 0) == "cn" ? true : false
+  is_aws_cn       = element(split("-", data.aws_region.current.region), 0) == "cn" ? true : false
   images          = var.environment == "prod" ? jsondecode(data.http.avx_ami_id.response_body)["g3"]["amd64"] : jsondecode(data.http.avx_ami_id.response_body)["g4"]["amd64"]
-  ami_id          = var.ami_id != "" ? var.ami_id : local.images[data.aws_region.current.name]
+  ami_id          = var.ami_id != "" ? var.ami_id : local.images[data.aws_region.current.region]
 
   common_tags = merge(
     var.tags, {

--- a/modules/copilot_build/outputs.tf
+++ b/modules/copilot_build/outputs.tf
@@ -24,7 +24,7 @@ output "vpc_name" {
 }
 
 output "region" {
-  value       = data.aws_region.current.name
+  value       = data.aws_region.current.region
   description = "Current AWS region"
 }
 

--- a/modules/copilot_build/variables.tf
+++ b/modules/copilot_build/variables.tf
@@ -206,7 +206,7 @@ locals {
   name_prefix         = var.name_prefix != "" ? "${var.name_prefix}_" : ""
   images_copilot      = jsondecode(data.http.copilot_iam_id.response_body).Copilot
   images_copilotarm   = jsondecode(data.http.copilot_iam_id.response_body).CopilotARM
-  ami_id              = var.ami_id != "" ? var.ami_id : var.type == "Copilot" ? local.images_copilot[data.aws_region.current.name] : local.images_copilotarm[data.aws_region.current.name]
+  ami_id              = var.ami_id != "" ? var.ami_id : var.type == "Copilot" ? local.images_copilot[data.aws_region.current.region] : local.images_copilotarm[data.aws_region.current.region]
   instance_type       = var.instance_type != "" ? var.instance_type : (var.type == "Copilot" ? "m5.2xlarge" : "t4g.2xlarge")
   default_az          = keys({ for az, details in data.aws_ec2_instance_type_offering.offering : az => details.instance_type if details.instance_type == local.instance_type })[0]
   availability_zone   = var.availability_zone != "" ? var.availability_zone : local.default_az

--- a/modules/iam_roles/variables.tf
+++ b/modules/iam_roles/variables.tf
@@ -34,8 +34,8 @@ locals {
   name_prefix          = var.name_prefix != "" ? "${var.name_prefix}-" : ""
   ec2_role_name        = var.ec2_role_name != "" ? var.ec2_role_name : "${local.name_prefix}aviatrix-role-ec2"
   app_role_name        = var.app_role_name != "" ? var.app_role_name : "${local.name_prefix}aviatrix-role-app"
-  arn_partition        = element(split("-", data.aws_region.current.name), 0) == "cn" ? "aws-cn" : (element(split("-", data.aws_region.current.name), 1) == "gov" ? "aws-us-gov" : "aws")
-  is_aws_cn            = element(split("-", data.aws_region.current.name), 0) == "cn" ? ".cn" : ""
+  arn_partition        = element(split("-", data.aws_region.current.region), 0) == "cn" ? "aws-cn" : (element(split("-", data.aws_region.current.region), 1) == "gov" ? "aws-us-gov" : "aws")
+  is_aws_cn            = element(split("-", data.aws_region.current.region), 0) == "cn" ? ".cn" : ""
   other_account_id     = data.aws_caller_identity.current.account_id
   resource_account_ids = length(var.secondary_account_ids) == 0 ? [local.other_account_id] : concat(var.secondary_account_ids, [local.other_account_id])
   resource_strings = [

--- a/versions.tf
+++ b/versions.tf
@@ -1,7 +1,10 @@
 terraform {
   required_providers {
     aviatrix = {
-      source  = "aviatrixsystems/aviatrix"
+      source = "aviatrixsystems/aviatrix"
+    }
+    aws = {
+      source  = "hashicorp/aws"
       version = ">= 6.0.0"
     }
   }

--- a/versions.tf
+++ b/versions.tf
@@ -1,7 +1,8 @@
 terraform {
   required_providers {
     aviatrix = {
-      source = "aviatrixsystems/aviatrix"
+      source  = "aviatrixsystems/aviatrix"
+      version = ">= 6.0.0"
     }
   }
   required_version = ">= 1.3"


### PR DESCRIPTION
What?
- Update AWS version and region references.

Why?
- AWS provider version 6.0.0 deprecated the old region reference syntax, preventing the code from running for users on that version.