### PR TITLE
Terraform module for setting up Copilot configures Controller IP instead of Gateway IP

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -86,6 +86,11 @@ module "copilot_build" {
       port     = 31283
       cidrs    = [format("%s/32", module.controller_build[0].public_ip)]
     }
+    "tcp_31283_cidrs" = {
+      protocol = "Tcp"
+      port     = 31283
+      cidrs    = [format("%s/32", module.controller_build[0].public_ip)]
+    }
   }
 }
 

--- a/main.tf
+++ b/main.tf
@@ -91,6 +91,11 @@ module "copilot_build" {
       port     = 31283
       cidrs    = var.incoming_ssl_cidrs
     }
+    "udp_5000_cidrs" = {
+      protocol = "Udp"
+      port     = 5000
+      cidrs    = var.incoming_ssl_cidrs
+    }
   }
 }
 

--- a/main.tf
+++ b/main.tf
@@ -84,12 +84,12 @@ module "copilot_build" {
     "udp_31283_cidrs" = {
       protocol = "Udp"
       port     = 31283
-      cidrs    = [format("%s/32", module.controller_build[0].public_ip)]
+      cidrs    = var.incoming_ssl_cidrs
     }
     "tcp_31283_cidrs" = {
       protocol = "Tcp"
       port     = 31283
-      cidrs    = [format("%s/32", module.controller_build[0].public_ip)]
+      cidrs    = var.incoming_ssl_cidrs
     }
   }
 }

--- a/modules/controller_build/README.md
+++ b/modules/controller_build/README.md
@@ -25,7 +25,7 @@ module "controller_build" {
 | <a name="input_controller_version"></a> [controller\_version](#input\_controller\_version) | Aviatrix Controller version | `string` | `"latest"` | no |
 | <a name="input_ec2_role_name"></a> [ec2\_role\_name](#input\_ec2\_role\_name) | EC2 role for controller | `string` | `""` | no |
 | <a name="input_incoming_ssl_cidrs"></a> [incoming\_ssl\_cidrs](#input\_incoming\_ssl\_cidrs) | Incoming cidr for security group used by controller | `list(string)` | n/a | yes |
-| <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | Controller instance size | `string` | `"t3.large"` | no |
+| <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | Controller instance size | `string` | `"t3.xlarge"` | no |
 | <a name="input_key_pair_name"></a> [key\_pair\_name](#input\_key\_pair\_name) | Key pair name | `string` | `""` | no |
 | <a name="input_name_prefix"></a> [name\_prefix](#input\_name\_prefix) | Additional name prefix for your environment resources | `string` | `""` | no |
 | <a name="input_root_volume_encrypted"></a> [root\_volume\_encrypted](#input\_root\_volume\_encrypted) | Whether the root volume is encrypted | `bool` | `true` | no |


### PR DESCRIPTION
When deploying the Controller and Copilot using the Terraform module, the Copilot's security group is incorrectly configured. Specifically, port 31283 (used by Copilot to receive NetFlow data from Gateways) is restricted to the Controller’s public IP address.

This configuration is incorrect because NetFlow data is sent from multiple Gateways, and the security group should allow ingress from Gateway IPs or, more generally, from any IPv4 address (0.0.0.0/0).

This issue does not occur when the Copilot is deployed via the Controller UI, as it correctly configures port 31283 to allow ingress from 0.0.0.0/0.



