### PR TITLE
Fix the controller instance termination problem

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -29,6 +29,7 @@ module "controller_build" {
   tags                      = var.tags
   name_prefix               = var.name_prefix
   ec2_role_name             = var.controller_ec2_role_name
+  termination_protection    = var.controller_termination_protection
   depends_on = [
     module.iam_roles
   ]

--- a/modules/controller_build/variables.tf
+++ b/modules/controller_build/variables.tf
@@ -70,7 +70,7 @@ variable "tags" {
 variable "termination_protection" {
   type        = bool
   description = "Enable/disable switch for termination protection"
-  default     = true
+  default     = false
   nullable    = false
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -214,3 +214,10 @@ variable "name_prefix" {
   type        = string
   default     = ""
 }
+
+variable "controller_termination_protection" {
+  type        = bool
+  description = "Enable/disable switch for termination protection"
+  default     = true
+  nullable    = false
+}

--- a/variables.tf
+++ b/variables.tf
@@ -218,6 +218,6 @@ variable "name_prefix" {
 variable "controller_termination_protection" {
   type        = bool
   description = "Enable/disable switch for termination protection"
-  default     = true
+  default     = false
   nullable    = false
 }


### PR DESCRIPTION
This PR fix the e2e infra controller cleaning problem. If customers can set controller_termination_protection to true if they need to disable API deletion.
`╷
│ Error: terminating EC2 Instance (i-03f1d6becb33683ef): operation error EC2: TerminateInstances, https response error StatusCode: 400, RequestID: fe261201-e1dc-49b6-88a6-5610c6c69180, api error OperationNotPermitted: The instance 'i-03f1d6becb33683ef' may not be terminated. Modify its 'disableApiTermination' instance attribute and try again.
│ 
│ 
╵
`