### PR TITLE
fix Unsupported argument for request_timeout

### DIFF
--- a/modules/controller_build/variables.tf
+++ b/modules/controller_build/variables.tf
@@ -221,5 +221,5 @@ data "http" "avx_ami_id" {
     Accept = "application/json"
   }
 
-  request_timeout = 60
+  request_timeout_ms = 60000
 }


### PR DESCRIPTION
https://registry.terraform.io/providers/hashicorp/http/latest/docs/data-sources/http
request_timeout is no longer supported in the http data-source
```
╷
│ Error: Unsupported argument
│ 
│   on .terraform/modules/my_controller/modules/controller_build/variables.tf line 224, in data "http" "avx_ami_id":
│  224:   request_timeout = 60
│ 
│ An argument named "request_timeout" is not expected here.
╵
```