### PR TITLE
Tag and encrypt Controller volumes

### DIFF
--- a/modules/controller_build/main.tf
+++ b/modules/controller_build/main.tf
@@ -143,6 +143,9 @@ resource "aws_instance" "aviatrix_controller" {
     encrypted             = var.root_volume_encrypted
     kms_key_id            = var.root_volume_kms_key_id
     delete_on_termination = true
+    tags = {
+      Name = "${local.name_prefix}controller"
+    }
   }
 
   user_data = var.user_data != "" ? var.user_data : local.cloud_init

--- a/modules/copilot_build/main.tf
+++ b/modules/copilot_build/main.tf
@@ -163,6 +163,11 @@ EOF
   root_block_device {
     volume_size = var.root_volume_size
     volume_type = var.root_volume_type
+    encrypted   = var.root_volume_encrypted
+    kms_key_id  = var.root_volume_kms_key_id
+    tags = {
+      Name = "${local.name_prefix}copilot"
+    }
   }
 
   tags = merge(local.common_tags, {
@@ -174,6 +179,8 @@ resource "aws_ebs_volume" "default" {
   count             = var.default_data_volume_name == "" ? 0 : 1
   availability_zone = data.aws_subnet.subnet.availability_zone
   size              = var.default_data_volume_size
+  encrypted         = var.default_data_volume_encrypted
+  kms_key_id        = var.default_data_volume_kms_key_id
   tags = {
     Name = "${local.name_prefix}copilot_default_data_volume"
   }

--- a/modules/copilot_build/variables.tf
+++ b/modules/copilot_build/variables.tf
@@ -76,6 +76,20 @@ variable "root_volume_type" {
   default     = "gp3"
 }
 
+variable "root_volume_encrypted" {
+  type        = bool
+  description = "Whether the root volume is encrypted"
+  default     = true
+  nullable    = false
+}
+
+variable "root_volume_kms_key_id" {
+  type        = string
+  description = "ARN for the key used to encrypt the root volume"
+  default     = ""
+  nullable    = false
+}
+
 variable "allowed_cidrs" {
   type = map(object({
     protocol  = string,
@@ -121,6 +135,20 @@ variable "default_data_volume_size" {
   default     = 50
   type        = number
   description = "Size of default data volume"
+}
+
+variable "default_data_volume_encrypted" {
+  type        = bool
+  description = "Whether the default data volume is encrypted"
+  default     = true
+  nullable    = false
+}
+
+variable "default_data_volume_kms_key_id" {
+  type        = string
+  description = "ARN for the key used to encrypt the default data volume"
+  default     = ""
+  nullable    = false
 }
 
 variable "additional_volumes" {


### PR DESCRIPTION
Ensure Controller volumes are gp3 and encrypted by default.
Tag volumes similar to how transit volumes are tagged.