### PR TITLE
Change output value to use region name

### DIFF
--- a/modules/copilot_build/outputs.tf
+++ b/modules/copilot_build/outputs.tf
@@ -24,7 +24,7 @@ output "vpc_name" {
 }
 
 output "region" {
-  value       = data.aws_region.current.region
+  value       = data.aws_region.current.name
   description = "Current AWS region"
 }
 


### PR DESCRIPTION
fixing:

Error: Unsupported attribute
│
│   on .terraform\modules\control_plane\modules\copilot_build\outputs.tf line 27, in output "region":
│   27:   value       = data.aws_region.current.region
│
│ This object has no argument, nested block, or exported attribute named "region".