### PR TITLE
copilot_build should support vpcs without names

### DIFF
--- a/modules/copilot_build/outputs.tf
+++ b/modules/copilot_build/outputs.tf
@@ -23,7 +23,7 @@ output "vpc_id" {
 }
 
 output "vpc_name" {
-  value       = data.aws_vpc.copilot_vpc.tags.Name
+  value       = lookup(data.aws_vpc.copilot_vpc.tags, "Name", null)
   description = "VPC name"
 }
 


### PR DESCRIPTION
copilot_build fails if a user passes in an existing vpc_id that has no Name tag.  Use lookup to gracefully fallback to null.