### PR TITLE
feat: expose cloud_type variable for GovCloud/China support

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ If you run into any issues, please check the [Common Issues Page](./docs/COMMON-
 ### Compatibility
 Module version | Terraform version
 :--- | :---
-v1.0.13 | >= 1.3.0
+v1.0.11 | >= 1.3.0
 
 ### Usage Example
 ```hcl
@@ -43,6 +43,7 @@ output "controlplane_data" {
 | <a name="input_access_account_name"></a> [access\_account\_name](#input\_access\_account\_name) | aviatrix controller access account name | `string` | n/a | yes |
 | <a name="input_account_email"></a> [account\_email](#input\_account\_email) | aviatrix controller access account email | `string` | n/a | yes |
 | <a name="input_availability_zone"></a> [availability\_zone](#input\_availability\_zone) | The Availability zone in which to deploy the controlplane. | `string` | `""` | no |
+| <a name="input_cloud_type"></a> [cloud\_type](#input\_cloud\_type) | Aviatrix cloud type of the access account used for account onboarding and CoPilot security group management (1 = AWS Commercial, 256 = AWS GovCloud, 1024 = AWS China). | `number` | `1` | no |
 | <a name="input_controller_admin_email"></a> [controller\_admin\_email](#input\_controller\_admin\_email) | aviatrix controller admin email address | `string` | n/a | yes |
 | <a name="input_controller_admin_password"></a> [controller\_admin\_password](#input\_controller\_admin\_password) | aviatrix controller admin password | `string` | n/a | yes |
 | <a name="input_controller_app_role_name"></a> [controller\_app\_role\_name](#input\_controller\_app\_role\_name) | APP role for controller | `string` | `null` | no |

--- a/main.tf
+++ b/main.tf
@@ -142,6 +142,7 @@ module "account_onboarding" {
 
   access_account_name = var.access_account_name
   account_email       = var.account_email
+  cloud_type          = var.cloud_type
   aws_role_ec2        = var.module_config.iam_roles ? module.iam_roles[0].aviatrix_role_ec2_name : var.controller_ec2_role_name
   aws_role_app        = var.module_config.iam_roles ? module.iam_roles[0].aviatrix_role_app_name : var.controller_app_role_name
 
@@ -157,6 +158,7 @@ module "sg_mgmt" {
   controller_admin_password                = var.controller_admin_password
   controller_admin_username                = null #Placeholder for future use
   enable_copilot_security_group_management = var.module_config.copilot_deployment
+  cloud_type                               = var.cloud_type
   access_account_name                      = var.access_account_name
   vpc_id                                   = local.vpc_id
   instance_id                              = var.module_config.copilot_deployment ? module.copilot_build[0].instance_id : ""

--- a/modules/account_onboarding/README.md
+++ b/modules/account_onboarding/README.md
@@ -23,6 +23,7 @@ module "account_onboarding" {
 | <a name="input_account_email"></a> [account\_email](#input\_account\_email) | Account email address | `string` | n/a | yes |
 | <a name="input_aws_role_app"></a> [aws\_role\_app](#input\_aws\_role\_app) | n/a | `string` | `"aviatrix-role-app"` | no |
 | <a name="input_aws_role_ec2"></a> [aws\_role\_ec2](#input\_aws\_role\_ec2) | n/a | `string` | `"aviatrix-role-ec2"` | no |
+| <a name="input_cloud_type"></a> [cloud\_type](#input\_cloud\_type) | Aviatrix cloud type of the access account (1 = AWS Commercial, 256 = AWS GovCloud, 1024 = AWS China). | `number` | `1` | no |
 | <a name="input_controller_admin_password"></a> [controller\_admin\_password](#input\_controller\_admin\_password) | aviatrix controller admin password | `string` | n/a | yes |
 | <a name="input_controller_admin_username"></a> [controller\_admin\_username](#input\_controller\_admin\_username) | aviatrix controller admin username | `string` | `"admin"` | no |
 | <a name="input_controller_public_ip"></a> [controller\_public\_ip](#input\_controller\_public\_ip) | aviatrix controller public ip address(required) | `string` | n/a | yes |

--- a/modules/account_onboarding/main.tf
+++ b/modules/account_onboarding/main.tf
@@ -25,6 +25,12 @@ data "http" "controller_login" {
 
 data "aws_caller_identity" "current" {}
 
+locals {
+  # IAM ARN partition must match the target cloud (GovCloud/China use a
+  # different partition than AWS Commercial).
+  arn_partition = var.cloud_type == 256 ? "aws-us-gov" : (var.cloud_type == 1024 ? "aws-cn" : "aws")
+}
+
 resource "terracurl_request" "aws_access_account" {
   name            = "aws_access_account"
   url             = "https://${var.controller_public_ip}/v2/api"
@@ -35,12 +41,12 @@ resource "terracurl_request" "aws_access_account" {
     action             = "setup_account_profile",
     CID                = jsondecode(data.http.controller_login.response_body)["CID"],
     account_name       = var.access_account_name,
-    cloud_type         = "1",
+    cloud_type         = tostring(var.cloud_type),
     account_email      = var.account_email,
     aws_account_number = data.aws_caller_identity.current.account_id,
     aws_iam            = true,
-    aws_role_ec2       = format("arn:aws:iam::%s:role/%s", data.aws_caller_identity.current.account_id, var.aws_role_ec2),
-    aws_role_arn       = format("arn:aws:iam::%s:role/%s", data.aws_caller_identity.current.account_id, var.aws_role_app)
+    aws_role_ec2       = format("arn:%s:iam::%s:role/%s", local.arn_partition, data.aws_caller_identity.current.account_id, var.aws_role_ec2),
+    aws_role_arn       = format("arn:%s:iam::%s:role/%s", local.arn_partition, data.aws_caller_identity.current.account_id, var.aws_role_app)
   })
 
   headers = {

--- a/modules/account_onboarding/variables.tf
+++ b/modules/account_onboarding/variables.tf
@@ -38,6 +38,18 @@ variable "aws_role_app" {
   nullable = false
 }
 
+variable "cloud_type" {
+  type        = number
+  description = "Aviatrix cloud type of the access account (1 = AWS Commercial, 256 = AWS GovCloud, 1024 = AWS China)."
+  default     = 1
+  nullable    = false
+
+  validation {
+    condition     = contains([1, 256, 1024], var.cloud_type)
+    error_message = "cloud_type must be one of 1 (AWS), 256 (AWS GovCloud), or 1024 (AWS China)."
+  }
+}
+
 # terraform-docs-ignore
 variable "destroy_url" {
   type        = string

--- a/modules/sg_mgmt/README.md
+++ b/modules/sg_mgmt/README.md
@@ -18,6 +18,7 @@ module "controller_sg_mgmt" {
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_access_account_name"></a> [access\_account\_name](#input\_access\_account\_name) | Aviatrix access account name | `string` | n/a | yes |
+| <a name="input_cloud_type"></a> [cloud\_type](#input\_cloud\_type) | Aviatrix cloud type of the access account (1 = AWS Commercial, 256 = AWS GovCloud, 1024 = AWS China). | `number` | `1` | no |
 | <a name="input_controller_admin_password"></a> [controller\_admin\_password](#input\_controller\_admin\_password) | aviatrix controller admin password | `string` | n/a | yes |
 | <a name="input_controller_admin_username"></a> [controller\_admin\_username](#input\_controller\_admin\_username) | aviatrix controller admin username | `string` | `"admin"` | no |
 | <a name="input_controller_public_ip"></a> [controller\_public\_ip](#input\_controller\_public\_ip) | aviatrix controller public ip address(required) | `string` | n/a | yes |

--- a/modules/sg_mgmt/main.tf
+++ b/modules/sg_mgmt/main.tf
@@ -55,7 +55,7 @@ resource "terracurl_request" "copilot_security_group_management" {
   request_body = jsonencode({
     action       = "enable_copilot_sg",
     CID          = local.current_cid,
-    cloud_type   = 1,
+    cloud_type   = var.cloud_type,
     account_name = var.access_account_name
     vpc_id       = var.vpc_id,
     instance_id  = var.instance_id,
@@ -73,7 +73,7 @@ resource "terracurl_request" "copilot_security_group_management" {
   destroy_request_body = jsonencode({
     action       = "disable_copilot_sg",
     CID          = local.current_cid
-    cloud_type   = 1,
+    cloud_type   = var.cloud_type,
     account_name = var.access_account_name,
     vpc_id       = var.vpc_id,
     instance_id  = var.instance_id,

--- a/modules/sg_mgmt/variables.tf
+++ b/modules/sg_mgmt/variables.tf
@@ -46,3 +46,15 @@ variable "enable_copilot_security_group_management" {
   default     = true
   nullable    = false
 }
+
+variable "cloud_type" {
+  type        = number
+  description = "Aviatrix cloud type of the access account (1 = AWS Commercial, 256 = AWS GovCloud, 1024 = AWS China)."
+  default     = 1
+  nullable    = false
+
+  validation {
+    condition     = contains([1, 256, 1024], var.cloud_type)
+    error_message = "cloud_type must be one of 1 (AWS), 256 (AWS GovCloud), or 1024 (AWS China)."
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -210,6 +210,18 @@ variable "module_config" {
   }
 }
 
+variable "cloud_type" {
+  type        = number
+  description = "Aviatrix cloud type of the access account used for account onboarding and CoPilot security group management (1 = AWS Commercial, 256 = AWS GovCloud, 1024 = AWS China)."
+  default     = 1
+  nullable    = false
+
+  validation {
+    condition     = contains([1, 256, 1024], var.cloud_type)
+    error_message = "cloud_type must be one of 1 (AWS), 256 (AWS GovCloud), or 1024 (AWS China)."
+  }
+}
+
 # terraform-docs-ignore
 variable "environment" {
   description = "Determines the deployment environment. For internal use only."


### PR DESCRIPTION
## What

Adds an optional `cloud_type` variable (default `1` = AWS Commercial) and threads it into the `account_onboarding` and `sg_mgmt` submodules, replacing the hardcoded `cloud_type = 1` in the controller API calls.

## Why

Both submodules currently hardcode `cloud_type = 1` (AWS Commercial):

- `modules/account_onboarding/main.tf` → `setup_account_profile`
- `modules/sg_mgmt/main.tf` → `enable_copilot_sg` / `disable_copilot_sg`

As a result, in **AWS GovCloud** (`cloud_type = 256`) and **AWS China** (`1024`) these calls fail with `Invalid account`, because the account onboarded on the controller is not `cloud_type 1`. This makes account onboarding and CoPilot Security Group Management unusable outside AWS Commercial via this module.

## Changes

- New `cloud_type` variable at the root and in both submodules (`default = 1`, validated against `[1, 256, 1024]`).
- Root module passes `var.cloud_type` to `account_onboarding` and `sg_mgmt`.
- `account_onboarding` also derives the IAM ARN partition (`aws` / `aws-us-gov` / `aws-cn`) so the `aws_role_ec2` / `aws_role_arn` ARNs are valid in the target partition (a GovCloud account needs `arn:aws-us-gov:...`).
- Regenerated docs via `terraform-docs`.

## Backward compatibility

Fully backward compatible — `cloud_type` defaults to `1`, so existing AWS Commercial deployments are unaffected.

## Testing

Verified against a live Aviatrix Controller (8.2) in **AWS GovCloud (`us-gov-west-1`)**: with `cloud_type = 256`, CoPilot Security Group Management enables successfully (controller creates and attaches the managed `Aviatrix-SG-*` groups to the CoPilot instance), whereas the stock `cloud_type = 1` call returns `Invalid account`.
